### PR TITLE
Updated the 201 error message description

### DIFF
--- a/product_schema_def/xsl/productSchema-wadl.xsl
+++ b/product_schema_def/xsl/productSchema-wadl.xsl
@@ -290,7 +290,7 @@
                     </request>
                     <!-- Okay -->
                     <response status="201" >
-            			<wadl:doc title="Created">The request has been fulfilled. The domain has been created.</wadl:doc>
+            			<wadl:doc title="Created">The request has been fulfilled. The entry has been created.</wadl:doc>
         			</response>
                     <!-- On Error -->
                     <response status="400">


### PR DESCRIPTION
Description said:  Domain created.   Changed to more generic, "entry created"  to fit Cloud Feeds context per PR review comments.